### PR TITLE
Allow SERVER_URI to be injected

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "yup": "^0.29.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "dev": "NODE_ENV=development react-scripts start",
-    "build": "react-scripts build",
+    "start": "REACT_APP_SERVER_URI=$REACT_APP_SERVER_URI react-scripts start",
+    "dev": "NODE_ENV=development REACT_APP_SERVER_URI=$REACT_APP_SERVER_URI react-scripts start",
+    "build": "REACT_APP_SERVER_URI=$REACT_APP_SERVER_URI react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
 export const APP_NAME = "todoapp"
-export const SERVER_URI = "http://localhost:3001/graphql"
+export const SERVER_URI =
+  process.env.REACT_APP_SERVER_URI || "http://localhost:3001/graphql"
 export const JWT_SESSION_STORAGE_KEY = `${APP_NAME}_jwt`


### PR DESCRIPTION
Mainly for `yarn build`, so server URI can be injected during frontend builds.