### PR TITLE
App Initialization Cleanup

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,14 +1,12 @@
 import { observer } from "mobx-react-lite"
-import React, { Fragment, useEffect } from "react"
-import { useStore } from "src/getMstGql"
+import React, { Fragment } from "react"
+import { usePromise, useStore } from "src/getMstGql"
 
 const AuthProvider: React.FC = observer(({ children }) => {
   const store = useStore()
-  useEffect(() => {
-    store.initializeApp()
-  }, [store])
+  const { loading } = usePromise(store.initializeApp())
 
-  return !store.initialized ? null : <Fragment>{children}</Fragment>
+  return loading ? null : <Fragment>{children}</Fragment>
 })
 
 export default AuthProvider

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,10 +1,14 @@
-import React, { Fragment } from "react"
 import { observer } from "mobx-react-lite"
-import { useQuery } from "../models/reactUtils"
+import React, { Fragment, useEffect } from "react"
+import { useStore } from "src/getMstGql"
 
 const AuthProvider: React.FC = observer(({ children }) => {
-  const { loading } = useQuery((store) => store.refreshTokenAndSetTimeOut())
-  return loading ? null : <Fragment>{children}</Fragment>
+  const store = useStore()
+  useEffect(() => {
+    store.initializeApp()
+  }, [store])
+
+  return !store.initialized ? null : <Fragment>{children}</Fragment>
 })
 
 export default AuthProvider

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite"
 import React, { Fragment } from "react"
-import { usePromise, useStore } from "src/getMstGql"
+import { useStore } from "src/getMstGql"
+import { usePromise } from "src/utilities/promises"
 
 const AuthProvider: React.FC = observer(({ children }) => {
   const store = useStore()

--- a/src/getMstGql.ts
+++ b/src/getMstGql.ts
@@ -1,5 +1,5 @@
 import { createHttpClient } from "mst-gql"
-import { useContext } from "react"
+import { useContext, useState } from "react"
 import { SERVER_URI } from "./config"
 import { RootStore, RootStoreType } from "./models"
 import { StoreContext } from "./models/reactUtils"
@@ -30,3 +30,28 @@ if (process.env.NODE_ENV === "development") {
 }
 
 export const useStore = (): RootStoreType => useContext(StoreContext)
+
+export type UsePromiseResponse<T> = {
+  loading: boolean
+  data: T | undefined
+  error: Error | undefined
+}
+
+export const usePromise = <T>(promise: PromiseLike<T>): UsePromiseResponse<T> => {
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState<T | undefined>(undefined)
+  const [error, setError] = useState<Error | undefined>(undefined)
+
+  promise.then(
+    (data) => {
+      setData(data)
+      setLoading(false)
+    },
+    (err: Error) => {
+      setError(err)
+      setLoading(false)
+    },
+  )
+
+  return { loading, data, error }
+}

--- a/src/getMstGql.ts
+++ b/src/getMstGql.ts
@@ -1,5 +1,5 @@
 import { createHttpClient } from "mst-gql"
-import { useContext, useState } from "react"
+import { useContext } from "react"
 import { SERVER_URI } from "./config"
 import { RootStore, RootStoreType } from "./models"
 import { StoreContext } from "./models/reactUtils"
@@ -30,28 +30,3 @@ if (process.env.NODE_ENV === "development") {
 }
 
 export const useStore = (): RootStoreType => useContext(StoreContext)
-
-export type UsePromiseResponse<T> = {
-  loading: boolean
-  data: T | undefined
-  error: Error | undefined
-}
-
-export const usePromise = <T>(promise: PromiseLike<T>): UsePromiseResponse<T> => {
-  const [loading, setLoading] = useState(true)
-  const [data, setData] = useState<T | undefined>(undefined)
-  const [error, setError] = useState<Error | undefined>(undefined)
-
-  promise.then(
-    (data) => {
-      setData(data)
-      setLoading(false)
-    },
-    (err: Error) => {
-      setError(err)
-      setLoading(false)
-    },
-  )
-
-  return { loading, data, error }
-}

--- a/src/models/Authentication.ts
+++ b/src/models/Authentication.ts
@@ -1,5 +1,6 @@
 import jwtDecode from "jwt-decode"
-import { types, getEnv } from "mobx-state-tree"
+import { getEnv, Instance, types } from "mobx-state-tree"
+import { UserModel, UserModelType } from "src/models/UserModel"
 import { getAuthHeader } from "../utilities/jwtHelpers"
 
 interface DecodedJwt {
@@ -9,6 +10,7 @@ interface DecodedJwt {
 const Authentication = types
   .model("Authentication", {
     token: types.maybeNull(types.string),
+    currentUser: types.maybeNull(types.reference(UserModel)),
   })
   .views((self) => ({
     isLoggedIn() {
@@ -25,6 +27,9 @@ const Authentication = types
       getEnv(self).gqlHttpClient.setHeaders({
         Authorization: getAuthHeader(token),
       })
+    },
+    setCurrentUser(user: Instance<UserModelType>) {
+      self.currentUser = user
     },
   }))
 

--- a/src/models/Authentication.ts
+++ b/src/models/Authentication.ts
@@ -1,6 +1,6 @@
 import jwtDecode from "jwt-decode"
-import { getEnv, Instance, types } from "mobx-state-tree"
-import { UserModel, UserModelType } from "src/models/UserModel"
+import { getEnv, types } from "mobx-state-tree"
+import { UserModel } from "src/models/UserModel"
 import { getAuthHeader } from "../utilities/jwtHelpers"
 
 interface DecodedJwt {
@@ -27,9 +27,6 @@ const Authentication = types
       getEnv(self).gqlHttpClient.setHeaders({
         Authorization: getAuthHeader(token),
       })
-    },
-    setCurrentUser(user: Instance<UserModelType>) {
-      self.currentUser = user
     },
   }))
 

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -22,7 +22,6 @@ const REFRESH_API_TOKEN_INTERVAL = 900000
 
 export const RootStore = RootStoreBase.props({
   authentication: Authentication,
-  initialized: false,
 })
   .actions((self) => ({
     createPost(
@@ -66,7 +65,6 @@ export const RootStore = RootStoreBase.props({
         }
         const token = refreshTokenResponse.refreshToken.token
         if (!token) {
-          self.initialized = true
           return
         }
 
@@ -81,8 +79,6 @@ export const RootStore = RootStoreBase.props({
         self.authentication.setCurrentUser(whoAmIResponse.whoAmI)
       } catch (error) {
         console.error(`Error initializing app: ${error}`)
-      } finally {
-        self.initialized = true
       }
     }),
   }))

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -1,6 +1,7 @@
-import { getEnv, Instance } from "mobx-state-tree"
+import { flow, getEnv, Instance } from "mobx-state-tree"
 import { Query } from "mst-gql"
 import Authentication from "src/models/Authentication"
+import { RefreshTokenResponseModelType } from "src/models/RefreshTokenResponseModel"
 import { MutationResponseModelType } from "./MutationResponseModel"
 import { PostCreationResponseModelType } from "./PostCreationResponseModel"
 import { postCreationResponseModelPrimitives } from "./PostCreationResponseModel.base"
@@ -13,7 +14,7 @@ import {
 } from "./RootStore.base"
 import { UserCreationResponseModelType } from "./UserCreationResponseModel"
 import { UserLoginResponseModelType } from "./UserLoginResponseModel"
-import { userModelPrimitives } from "./UserModel"
+import { userModelPrimitives, UserModelType } from "./UserModel"
 
 export interface RootStoreType extends Instance<typeof RootStore> {}
 
@@ -21,6 +22,7 @@ const REFRESH_API_TOKEN_INTERVAL = 900000
 
 export const RootStore = RootStoreBase.props({
   authentication: Authentication,
+  initialized: false,
 })
   .actions((self) => ({
     createPost(
@@ -57,6 +59,34 @@ export const RootStore = RootStoreBase.props({
     },
   }))
   .actions((self) => ({
+    initializeApp: flow(function* initializeApp() {
+      try {
+        const refreshTokenResponse = (yield self.mutateRefreshToken().currentPromise()) as {
+          refreshToken: RefreshTokenResponseModelType
+        }
+        const token = refreshTokenResponse.refreshToken.token
+        if (!token) {
+          self.initialized = true
+          return
+        }
+
+        self.authentication.setToken(token.toString())
+        setTimeout(() => {
+          self.refreshTokenAndSetTimeOut()
+        }, REFRESH_API_TOKEN_INTERVAL)
+
+        const whoAmIResponse = (yield self.queryWhoAmI().currentPromise()) as {
+          whoAmI: UserModelType
+        }
+        self.authentication.setCurrentUser(whoAmIResponse.whoAmI)
+      } catch (error) {
+        console.error(`Error initializing app: ${error}`)
+      } finally {
+        self.initialized = true
+      }
+    }),
+  }))
+  .actions((self) => ({
     login(input: UserLoginArgs): Query<{ login: UserLoginResponseModelType }> {
       const query = self.mutateLogin({ input })
       query.then(({ login: { token } }) => {
@@ -64,24 +94,23 @@ export const RootStore = RootStoreBase.props({
           self.authentication.setToken(token)
         }
         setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-          // @ts-ignore
           self.refreshTokenAndSetTimeOut()
         }, REFRESH_API_TOKEN_INTERVAL)
       })
 
       return query
     },
-  }))
-  .actions((self) => ({
     logout(): Query<{ logout: MutationResponseModelType }> {
       const query = self.mutateLogout()
       query.then(() => {
         self.authentication.token = null
+        self.authentication.currentUser = null
         getEnv(self).gqlHttpClient.setHeaders({ authorization: "" })
       })
       return query
     },
+  }))
+  .actions((self) => ({
     createUserAndLogin(
       input: CreateUserInput,
     ): Query<{ createUser: UserCreationResponseModelType }> {

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -79,6 +79,7 @@ export const RootStore = RootStoreBase.props({
         self.authentication.setCurrentUser(whoAmIResponse.whoAmI)
       } catch (error) {
         console.error(`Error initializing app: ${error}`)
+        throw error
       }
     }),
   }))

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -74,9 +74,9 @@ export const RootStore = RootStoreBase.props({
         }, REFRESH_API_TOKEN_INTERVAL)
 
         const whoAmIResponse = (yield self.queryWhoAmI().currentPromise()) as {
-          whoAmI: UserModelType
+          whoAmI: UserModelType | undefined
         }
-        self.authentication.setCurrentUser(whoAmIResponse.whoAmI)
+        self.authentication.currentUser = whoAmIResponse.whoAmI || null
       } catch (error) {
         console.error(`Error initializing app: ${error}`)
         throw error

--- a/src/utilities/promises.ts
+++ b/src/utilities/promises.ts
@@ -1,0 +1,26 @@
+import { useState } from "react"
+
+export type UsePromiseResponse<T> = {
+  loading: boolean
+  data: T | undefined
+  error: Error | undefined
+}
+
+export const usePromise = <T>(promise: PromiseLike<T>): UsePromiseResponse<T> => {
+  const [loading, setLoading] = useState(true)
+  const [data, setData] = useState<T | undefined>(undefined)
+  const [error, setError] = useState<Error | undefined>(undefined)
+
+  promise.then(
+    (data) => {
+      setData(data)
+      setLoading(false)
+    },
+    (err: Error) => {
+      setError(err)
+      setLoading(false)
+    },
+  )
+
+  return { loading, data, error }
+}


### PR DESCRIPTION
Moves initialization of token and current user into a flow based action to ensure the sequencing is correct. We were having an issue before where the return from the `useQuery((store) => store.refreshTokenAndSetTimeOut())` call would be `loading === false` but the additional state changes being made inside the `then` of the action would not have completed yet, causing the app to load in a weird state that caused multiple redirects before finally landing on the `Home` route (assuming the user was logged in).