### PR TITLE
CD - update terraform version, trigger dev environment update

### DIFF
--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -1,9 +1,9 @@
 name: Continuous Delivery
 # This workflow is triggered on pushes to master
-on:
-  push:
-    branches:
-      - master
+on: push
+#  push:
+#    branches:
+#      - master
 jobs:
   build:
     name: Create minor version on push to master
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build, tag, and push build to Amazon S3
+        id: build-push-assets
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           SERVER_URI: ${{ secrets.SERVER_URI }}
@@ -43,3 +44,25 @@ jobs:
           git push origin $RELEASE_VERSION
           REACT_APP_SERVER_URI=${SERVER_URI} PUBLIC_URL=${PUBLIC_URL}/${RELEASE_VERSION} npm run build
           aws s3 cp build/ s3://${AWS_S3_BUCKET}/${RELEASE_VERSION} --recursive
+          echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
+      - name: Checkout Terraform Repo
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ secrets.TERRAFORM_REPO_ORG }}/${{ secrets.TERRAFORM_REPO_NAME }}
+          ssh-key: ${{ secrets.TERRAFORM_DEPLOY_KEY }}
+          path: ${{ secrets.TERRAFORM_REPO_NAME }}
+      - name: Update Dev Environment with new assets version
+        env:
+          RELEASE_VERSION: ${{ steps.build-push-assets.outputs.RELEASE_VERSION }}
+          TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
+          TERRAFORM_REPO_ORG: ${{ secrets.TERRAFORM_REPO_ORG }}
+          TERRAFORM_REPO_VERSION_PATH: ${{ secrets.TERRAFORM_REPO_VERSION_PATH }}
+        run: |
+          git config --global user.email "github-actions@$TERRAFORM_REPO_ORG.com"
+          git config --global user.name "github actions"
+          cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME
+          echo -n "$RELEASE_VERSION" > $TERRAFORM_REPO_VERSION_PATH
+          git add $TERRAFORM_REPO_VERSION_PATH
+          git commit -m "Update dev version to $RELEASE_VERSION"
+          git push origin master
+          echo "Dev version updated in terraform.  See https://github.com/$TERRAFORM_REPO_ORG/$TERRAFORM_REPO_NAME/actions for deploy progress"

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -45,7 +45,7 @@ jobs:
           RELEASE_VERSION=$(npm version minor -m "Updating version to %s")
           echo "RELEASE_VERSION: ${RELEASE_VERSION}"
           echo "current branch: $(git branch)"
-          git push origin master
+          git push origin ci_cd_versions
           echo "current branch: $(git branch)"
           git push origin $RELEASE_VERSION
           REACT_APP_SERVER_URI=${SERVER_URI} PUBLIC_URL=${PUBLIC_URL}/${RELEASE_VERSION} npm run build

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -68,6 +68,6 @@ jobs:
           cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME
           echo -n "$RELEASE_VERSION" > $TERRAFORM_REPO_VERSION_PATH
           git add $TERRAFORM_REPO_VERSION_PATH
-          git commit -m "Update dev version to $RELEASE_VERSION"
+          git commit -m "$GITHUB_REPOSITORY: update dev version to $RELEASE_VERSION"
           git push origin master
           echo "Dev version updated in terraform.  See terraform repo's github actions for deploy progress."

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -61,14 +61,13 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.build-push-assets.outputs.RELEASE_VERSION }}
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
-          TERRAFORM_REPO_ORG: ${{ secrets.TERRAFORM_REPO_ORG }}
           TERRAFORM_REPO_VERSION_PATH: ${{ secrets.TERRAFORM_REPO_VERSION_PATH }}
         run: |
-          git config --global user.email "github-actions@$TERRAFORM_REPO_ORG.com"
+          git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
           cd $GITHUB_WORKSPACE/$TERRAFORM_REPO_NAME
           echo -n "$RELEASE_VERSION" > $TERRAFORM_REPO_VERSION_PATH
           git add $TERRAFORM_REPO_VERSION_PATH
           git commit -m "Update dev version to $RELEASE_VERSION"
           git push origin master
-          echo "Dev version updated in terraform.  See https://github.com/$TERRAFORM_REPO_ORG/$TERRAFORM_REPO_NAME/actions for deploy progress"
+          echo "Dev version updated in terraform.  See terraform repo's github actions for deploy progress."

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          path: main
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -35,6 +37,7 @@ jobs:
           SERVER_URI: ${{ secrets.SERVER_URI }}
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
         run: |
+          cd $GITHUB_WORKSPACE/main
           yarn install
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build, tag, and push build to Amazon S3
-        id: build-push-assets
+        id: build-push
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           SERVER_URI: ${{ secrets.SERVER_URI }}
@@ -57,7 +57,7 @@ jobs:
           path: ${{ secrets.TERRAFORM_REPO_NAME }}
       - name: Update Dev Environment with new assets version
         env:
-          RELEASE_VERSION: ${{ steps.build-push-assets.outputs.RELEASE_VERSION }}
+          RELEASE_VERSION: ${{ steps.build-push.outputs.RELEASE_VERSION }}
           TERRAFORM_REPO_NAME: ${{ secrets.TERRAFORM_REPO_NAME }}
           TERRAFORM_REPO_VERSION_PATH: ${{ secrets.TERRAFORM_REPO_VERSION_PATH }}
         run: |

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -38,12 +38,15 @@ jobs:
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
         run: |
           cd $GITHUB_WORKSPACE/main
+          git status
           yarn install
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
           RELEASE_VERSION=$(npm version minor -m "Updating version to %s")
           echo "RELEASE_VERSION: ${RELEASE_VERSION}"
+          echo "current branch: $(git branch)"
           git push origin master
+          echo "current branch: $(git branch)"
           git push origin $RELEASE_VERSION
           REACT_APP_SERVER_URI=${SERVER_URI} PUBLIC_URL=${PUBLIC_URL}/${RELEASE_VERSION} npm run build
           aws s3 cp build/ s3://${AWS_S3_BUCKET}/${RELEASE_VERSION} --recursive

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -1,9 +1,10 @@
 name: Continuous Delivery
 # This workflow is triggered on pushes to master
-on: push
-#  push:
-#    branches:
-#      - master
+on:
+  push:
+    branches:
+      - master
+
 jobs:
   build:
     name: Create minor version on push to master

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -44,7 +44,7 @@ jobs:
           git config --global user.name "github actions"
           RELEASE_VERSION=$(npm version minor -m "Updating version to %s")
           echo "RELEASE_VERSION: ${RELEASE_VERSION}"
-          git push origin ci_cd_versions
+          git push origin master
           git push origin $RELEASE_VERSION
           REACT_APP_SERVER_URI=${SERVER_URI} PUBLIC_URL=${PUBLIC_URL}/${RELEASE_VERSION} npm run build
           aws s3 cp build/ s3://${AWS_S3_BUCKET}/${RELEASE_VERSION} --recursive

--- a/.github/workflows/create-minor-version-on-push-to-master.yml
+++ b/.github/workflows/create-minor-version-on-push-to-master.yml
@@ -39,15 +39,12 @@ jobs:
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
         run: |
           cd $GITHUB_WORKSPACE/main
-          git status
           yarn install
           git config --global user.email "github-actions@bitmatica.com"
           git config --global user.name "github actions"
           RELEASE_VERSION=$(npm version minor -m "Updating version to %s")
           echo "RELEASE_VERSION: ${RELEASE_VERSION}"
-          echo "current branch: $(git branch)"
           git push origin ci_cd_versions
-          echo "current branch: $(git branch)"
           git push origin $RELEASE_VERSION
           REACT_APP_SERVER_URI=${SERVER_URI} PUBLIC_URL=${PUBLIC_URL}/${RELEASE_VERSION} npm run build
           aws s3 cp build/ s3://${AWS_S3_BUCKET}/${RELEASE_VERSION} --recursive

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blogmatica-mst-apollo",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "devDependencies": {
     "@types/camelcase": "^5.2.0",


### PR DESCRIPTION
Update dev asset bundle version (commit to master) in cloud_infrastructure repo, which triggers a dev `terraform apply` in cloud_infrastructure github action.

Prereq:
- Deploy key for infra repo (among other vars) is provisioned by terraform and added as a github action secret

See notes on https://github.com/bitmatica/nest-blogmatica/pull/29